### PR TITLE
typo: 修复几个链接的错误

### DIFF
--- a/plugins/vitepress-plugin-file-content-loader/package.json
+++ b/plugins/vitepress-plugin-file-content-loader/package.json
@@ -15,7 +15,7 @@
     "contentLoad"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/Kele-Bingtang/vitepress-theme-teek/tree/master/plugins/vitepress-plugin-catalogue",
+  "homepage": "https://github.com/Kele-Bingtang/vitepress-theme-teek/tree/master/plugins/vitepress-plugin-file-content-loader",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Kele-Bingtang/vitepress-theme-teek.git"

--- a/plugins/vitepress-plugin-md-h1/package.json
+++ b/plugins/vitepress-plugin-md-h1/package.json
@@ -15,7 +15,7 @@
     "mdH1"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/Kele-Bingtang/vitepress-theme-teek/tree/master/plugins/vitepress-plugin-catalogue",
+  "homepage": "https://github.com/Kele-Bingtang/vitepress-theme-teek/tree/master/plugins/vitepress-plugin-md-h1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Kele-Bingtang/vitepress-theme-teek.git"

--- a/plugins/vitepress-plugin-permalink/package.json
+++ b/plugins/vitepress-plugin-permalink/package.json
@@ -15,7 +15,7 @@
     "permalink"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/Kele-Bingtang/vitepress-theme-teek/tree/master/plugins/vitepress-plugin-catalogue",
+  "homepage": "https://github.com/Kele-Bingtang/vitepress-theme-teek/tree/master/plugins/vitepress-plugin-permalink",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Kele-Bingtang/vitepress-theme-teek.git"

--- a/plugins/vitepress-plugin-sidebar-resolve/package.json
+++ b/plugins/vitepress-plugin-sidebar-resolve/package.json
@@ -15,7 +15,7 @@
     "sidebar"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/Kele-Bingtang/vitepress-theme-teek/tree/master/plugins/vitepress-plugin-catalogue",
+  "homepage": "https://github.com/Kele-Bingtang/vitepress-theme-teek/tree/master/plugins/vitepress-plugin-sidebar-resolve",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Kele-Bingtang/vitepress-theme-teek.git"


### PR DESCRIPTION
如题：

<img width="1376" alt="image" src="https://github.com/user-attachments/assets/5ffc700b-fef7-4962-a8c8-f34ebf56c865" />
