### PR TITLE
feat(theme): 🚀 添加全局淡入动画效果

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,6 +4,11 @@
 
 ### 代办
 
+- 新增首页全新 Feature 组件
+- 添加常用 icon 库
+- 壁纸滚动 fixed
+- 主题增强面板主题色具象化
+
 ### issue
 
 ### 已完成
@@ -11,9 +16,9 @@
 ## AR
 
 - 修复浏览器报错：`Hydration completed but contains mismatches.`，官方解决方案：`https://cn.vuejs.org/guide/scaling-up/ssr#hydration-mismatch`
-- 添加常用 icon 库
 - 文章页分析区域支持自定义文字（插槽）
 - plus 样式示例编写
+- 页面全局 Loading 动画
 
 ## 空模板
 

--- a/docs/01.指南/01.简介/20.结构化目录.md
+++ b/docs/01.指南/01.简介/20.结构化目录.md
@@ -68,14 +68,14 @@ Teek 的自动生成侧边栏，自动生成 `frontmatter`、自动生成 `h1` �
 从维护性、可读性的角度分析，带有序号的文件名在本地磁盘看起来更加直观；从站点渲染的角度分析，在生成侧边栏时，Teek 会根据文件名的序号进行排序。
 :::
 
-如果不希望 URL 上带有链接，请给每一个 Markdown 指定一个永久链接 [frontmatter.permalink](http://localhost:5173/reference/frontmatter.html#permalink)。
+如果不希望 URL 上带有序号，请给每一个 Markdown 指定一个永久链接 [frontmatter.permalink](http://localhost:5173/reference/frontmatter.html#permalink)。
 
 ### 文档风 <Badge type="tip" text="v1.4.0" />
 
 如果你搭建的是文档风，那么大部分场景下，Markdown 文件名为英文格式，此时正好作为 URL 访问，此时会遇到一个问题：在生成侧边栏时，怎么按照自己的要求进行排序呢？
 
 - 仿照博客风给文件名添加序号，但是访问时 URL 会带上序号，这样看起来比较难受，为解决这个问题，你需要指定一个永久链接 `frontmatter.permalink`
-- 文件名不添加序号，通过 `frontmatter.sidebarSort` 指定排序，数值越小越靠前，数值的命名规则可以参考博客风：序号直接添加间隔
+- 文件名不添加序号，通过 `frontmatter.sidebarSort` 指定排序，数值越小越靠前，数值的命名规则可以参考博客风：序号之间添加间隔
 
 如果不指定 `frontmatter.sidebarSort`，那么 Teek 给每一个文件默认设置为 `9999`，因此如果给某一个文件的 `frontmatter.sidebarSort` 设置大于 9999，则排在侧边栏的最后面。
 

--- a/docs/10.配置/01.主题配置/05.全局配置.md
+++ b/docs/10.配置/01.主题配置/05.全局配置.md
@@ -370,6 +370,64 @@ const teekConfig = defineTeekConfig({
 
 如果想重写侧边栏展开/折叠触发器组件，则使用 [teek-sidebar-trigger](/guide/slot#全局插槽) 插槽。
 
+## fadeTransition <Badge type="tip" text="v1.4.1" />
+
+- 类型：`boolean` / `object`
+- 默认值：`true`
+
+是否全局启用 `fade` 过渡动画，当为 `boolean` 类型，则控制全局是否启用，当为 `object` 类型，则控制部分元素是否启用。
+
+`object` 为 `FadeTransition` 类型，请看下方代码块的 <mark>更多配置项</mark>。
+
+::: tip 什么是 `fade` 过渡动画
+当第一次进入博客风格的首页或者归档页时，向下滚动，会看到每一个元素的从下方向上移动的过渡效果。
+:::
+
+::: code-group
+
+```ts [config.mts]
+// .vitepress/config.mts
+import { defineTeekConfig } from "vitepress-theme-teek/config";
+
+const teekConfig = defineTeekConfig({
+  fadeTransition: true,
+});
+```
+
+```ts [更多配置项]
+interface TeekConfig {
+  /**
+   * 是否全局启用 fade 过渡动画
+   *
+   * @default true
+   */
+  fadeTransition?: boolean | FadeTransition;
+}
+
+interface FadeTransition {
+  /**
+   * 是否开启首页文章列表动画
+   *
+   * @default false
+   */
+  post?: boolean;
+  /**
+   * 是否开启首页卡片列表动画
+   *
+   * @default false
+   */
+  card?: boolean;
+  /**
+   * 是否开启归档页动画
+   *
+   * @default false
+   */
+  archives?: boolean;
+}
+```
+
+:::
+
 ## bodyBgImg
 
 body 背景图片配置，将整个网站的背景色改为图片。

--- a/docs/10.配置/01.主题配置/30.文章配置.md
+++ b/docs/10.配置/01.主题配置/30.文章配置.md
@@ -630,7 +630,7 @@ interface TeekConfig {
 
 文章页底部的最近更新栏配置。
 
-:::: code-group
+::: code-group
 
 ```ts [config.mts]
 // .vitepress/config.mts

--- a/docs/10.配置/01.主题配置/40.插件配置.md
+++ b/docs/10.配置/01.主题配置/40.插件配置.md
@@ -127,7 +127,7 @@ Teek 内置的 Markdown 插件详细介绍请看 [Markdown 拓展](/guide/markdo
 通过该 `config` 函数来加载更多的 `Markdown-it` 插件。
 
 ::: danger
-请不要在使用 VitePress 提供 `markdown.config` 函数来加载 `Markdown-it` 插件，因为 VitePress 方式会覆盖主题内置的 `Markdown-it` 插件。
+请不要使用 VitePress 提供 `markdown.config` 函数来加载 `Markdown-it` 插件，因为 VitePress 方式会覆盖主题内置的 `Markdown-it` 插件。
 :::
 
 ::: code-group

--- a/docs/30.生态/20.Composables 函数.md
+++ b/docs/30.生态/20.Composables 函数.md
@@ -641,3 +641,23 @@ nextZIndex(); // currentZIndex 递增
 `currentZIndex` 是一个全局的值，当任意组件调用 `nextZIndex` 时，所有组件获取的 `currentZIndex` 都会递增。
 
 一般用于弹框、提示等悬浮组件，避免 z-index 冲突。
+
+## useWindowTransition
+
+指定元素出现在屏幕内时，开启过渡效果。
+
+```ts
+import { useViewTransition } from "vitepress-theme-teek";
+
+/**
+ * 指定元素出现在屏幕内时，开启过渡效果
+ *
+ * @param htmlElement 要添加过渡效果的元素，支持数组（支持响应式变量）
+ * @param immediate 是否立即监听元素，如果为 false，则需要手动调用返回的 start 函数，默认 true
+ *
+ * @returnParam start 开启监听元素进入屏幕时开启过渡效果
+ * @returnParam stop 停止监听元素进入屏幕时开启过渡效果
+ * @returnParam restart 重启监听元素进入屏幕时开启过渡效果
+ */
+const { start, stop, restart } = useWindowTransition(htmlElement, immediate);
+```

--- a/packages/components/theme/ArchivesPage/src/index.vue
+++ b/packages/components/theme/ArchivesPage/src/index.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts" name="ArchivesPage">
 import { withBase, useData } from "vitepress";
-import { computed } from "vue";
-import { useNamespace, useLocale } from "@teek/composables";
-import { usePosts } from "@teek/components/theme/ConfigProvider";
+import { computed, onMounted, useTemplateRef } from "vue";
+import { useNamespace, useLocale, useWindowTransition } from "@teek/composables";
+import { useFadeTransition, usePosts } from "@teek/components/theme/ConfigProvider";
 import { TkArticlePage } from "@teek/components/common/ArticlePage";
 import { TkArticleTitle } from "@teek/components/theme/ArticleTitle";
 
@@ -25,6 +25,15 @@ const defaultLabel = computed(() => {
     count: frontmatterConst.count ?? t("tk.archives.count"),
     notFound: frontmatterConst.notFound ?? t("tk.archives.notFound"),
   };
+});
+
+// 屏幕加载元素时，开启过渡动画
+const fadeTransition = useFadeTransition(config => config.archives);
+const timelineItemListInstance = useTemplateRef("timelineItemListInstance");
+const { start } = useWindowTransition(timelineItemListInstance, false);
+
+onMounted(() => {
+  fadeTransition.value && start();
 });
 </script>
 
@@ -64,7 +73,7 @@ const defaultLabel = computed(() => {
             </div>
 
             <ul>
-              <li v-for="item in p" :key="item.url">
+              <li ref="timelineItemListInstance" v-for="item in p" :key="item.url">
                 <a :href="item.url && withBase(item.url)" :aria-label="`${item.title}`">
                   <span class="date">{{ item.date?.slice(5, 10) }}</span>
                   <TkArticleTitle :post="item" :title-tag-props="{ position: 'right', size: 'small' }" />

--- a/packages/components/theme/ArticleUpdate/src/index.vue
+++ b/packages/components/theme/ArticleUpdate/src/index.vue
@@ -55,7 +55,7 @@ const updatePosts = computed(() => {
         </span>
 
         <div :class="ns.e('content')">
-          <a v-if="item.url" :href="withBase(item.url)" class="flx-1 hover-color" :aria-label="item.title">
+          <a v-if="item.url" :href="withBase(item.url)" class="flx-1 hover-color sle" :aria-label="item.title">
             <TkArticleTitle :post="item" :title-tag-props="{ position: 'right', size: 'small' }" />
           </a>
           <span v-if="item.date" :class="ns.em('content', 'date')">{{ item.date }}</span>

--- a/packages/components/theme/ConfigProvider/index.ts
+++ b/packages/components/theme/ConfigProvider/index.ts
@@ -1,5 +1,5 @@
 import type { PostData } from "@teek/config/post/types";
-import type { TeekConfig } from "@teek/config";
+import type { FadeTransition, TeekConfig } from "@teek/config";
 import type { Component, Ref, InjectionKey } from "vue";
 import { computed, defineComponent, h, inject, provide, unref } from "vue";
 import { useData } from "vitepress";
@@ -210,6 +210,18 @@ export const useTagColor = () => {
     { border: "#a5f3fc", bg: "#ecfeff", text: "#0891b2" },
     { border: "#c7d2fe", bg: "#eef2ff", text: "#4f46e5" },
   ]);
+};
+
+export const useFadeTransition = (condition?: (fadeTransition: FadeTransition) => boolean | undefined) => {
+  const { getTeekConfigRef } = useTeekConfig();
+  const fadeTransitionConfig = getTeekConfigRef<FadeTransition>("fadeTransition", true);
+
+  return computed(() => {
+    const fadeTransition = fadeTransitionConfig.value;
+    if (fadeTransition === undefined) return true;
+
+    return isObject(fadeTransition) ? (condition?.(fadeTransition) ?? true) : fadeTransition !== false;
+  });
 };
 
 /**

--- a/packages/components/theme/SidebarTrigger/src/index.vue
+++ b/packages/components/theme/SidebarTrigger/src/index.vue
@@ -42,7 +42,7 @@ onMounted(async () => {
       :aria-label="t('tk.sidebarTrigger.label')"
     >
       <div :class="[ns.join('right-bottom-button__button')]">
-        <TkIcon :icon="autoWidthIcon" />
+        <TkIcon :icon="autoWidthIcon" aria-hidden="true" />
       </div>
     </div>
   </slot>

--- a/packages/composables/index.ts
+++ b/packages/composables/index.ts
@@ -19,4 +19,5 @@ export * from "./useThemeColor";
 export * from "./useViewTransition";
 export * from "./useVpRouter";
 export * from "./useWindowSize";
+export * from "./useWindowTransition";
 export * from "./useZIndex";

--- a/packages/composables/onClickOutside.ts
+++ b/packages/composables/onClickOutside.ts
@@ -1,7 +1,7 @@
 // From https://github.com/vueuse/vueuse/blob/main/packages/core/onClickOutside/index.ts
 import type { ComponentPublicInstance, MaybeRef, MaybeRefOrGetter, VNode } from "vue";
 import { toValue } from "vue";
-import { isClient, isIOS } from "@teek/helper";
+import { isClient, isIos } from "@teek/helper";
 import { useEventListener } from "./useEventListener";
 
 export type VueInstance = ComponentPublicInstance;
@@ -62,7 +62,7 @@ export const onClickOutside = (
     return controls ? { stop: () => {}, cancel: () => {}, trigger: () => {} } : () => {};
   }
 
-  if (isIOS() && !_iOSWorkaround) {
+  if (isIos() && !_iOSWorkaround) {
     _iOSWorkaround = true;
     const listenerOptions = { passive: true };
     Array.from(window.document.body.children).forEach(el => useEventListener(el, "click", () => {}, listenerOptions));

--- a/packages/composables/useWindowTransition.ts
+++ b/packages/composables/useWindowTransition.ts
@@ -1,0 +1,118 @@
+import { isArray } from "@teek/helper";
+import { useScopeDispose } from "./useScopeDispose";
+import { useMounted } from "./useMounted";
+import { MaybeRef, nextTick, unref, watch } from "vue";
+
+/**
+ * 元素出现在屏幕内时，开启过渡效果
+ */
+export const useWindowTransition = (element: MaybeRef<HTMLLIElement | HTMLElement[] | null>, immediate = true) => {
+  let startInMounted = false;
+  const cleanup: (() => void)[] = [];
+
+  /**
+   * 创建 IntersectionObserver 初始化监听屏幕外元素
+   */
+  const start = () => {
+    const elementConst = unref(element);
+    if (!elementConst) return;
+
+    if (isArray(elementConst)) elementConst.forEach(el => initTransition(el));
+    else initTransition(elementConst);
+  };
+
+  /**
+   * 初始化动画类
+   */
+  const initTransition = (el: HTMLElement) => {
+    // 初始化动画 class
+    el.classList.add("scroll__animate");
+
+    const { createIntersectionObserver, cleanIntersectionObserver } = useIntersectionObserver(
+      el,
+      entries => {
+        entries.forEach(entry => {
+          if (entry.isIntersecting) {
+            // 使用 requestAnimationFrame 确保在下一帧执行
+            requestAnimationFrame(() => {
+              try {
+                // 添加 visible class，触发动画
+                el.classList.add("visible");
+                cleanIntersectionObserver();
+              } catch (error) {
+                console.error("初始化动画失败:", error);
+              }
+            });
+          }
+        });
+      },
+      0.1
+    );
+
+    createIntersectionObserver();
+    cleanup.push(cleanIntersectionObserver);
+  };
+
+  /**
+   * 清除所有 IntersectionObserver
+   */
+  const stop = () => {
+    cleanup.forEach(fn => fn());
+  };
+
+  const restart = () => {
+    stop();
+    start();
+  };
+
+  watch(
+    () => unref(element),
+    () => {
+      !startInMounted && restart();
+    },
+    { deep: true }
+  );
+
+  useMounted(async () => {
+    // 防止 watch 立即执行
+    startInMounted = true;
+    immediate && restart();
+
+    await nextTick();
+    startInMounted = false;
+  });
+
+  useScopeDispose(stop);
+
+  return { start, stop, restart };
+};
+
+/**
+ * 使用 IntersectionObserver 监听元素是否可见
+ */
+export const useIntersectionObserver = (
+  observerDom: HTMLElement,
+  callback: (entries: IntersectionObserverEntry[]) => void,
+  threshold: number
+) => {
+  let intersectionObserver: IntersectionObserver | null = null;
+
+  // 创建 IntersectionObserver
+  const createIntersectionObserver = () => {
+    const observerDomValue = observerDom;
+    if (intersectionObserver || !observerDomValue) return;
+
+    intersectionObserver = new IntersectionObserver(callback, { threshold });
+    intersectionObserver.observe(observerDomValue);
+  };
+
+  // 清理 IntersectionObserver
+  const cleanIntersectionObserver = () => {
+    if (intersectionObserver) {
+      intersectionObserver.disconnect();
+      intersectionObserver = null;
+    }
+  };
+
+  return { createIntersectionObserver, cleanIntersectionObserver };
+};

--- a/packages/config/interface/fadeTransition.ts
+++ b/packages/config/interface/fadeTransition.ts
@@ -1,0 +1,20 @@
+export interface FadeTransition {
+  /**
+   * 是否开启首页文章列表动画
+   *
+   * @default false
+   */
+  post?: boolean;
+  /**
+   * 是否开启首页卡片列表动画
+   *
+   * @default false
+   */
+  card?: boolean;
+  /**
+   * 是否开启归档页动画
+   *
+   * @default false
+   */
+  archives?: boolean;
+}

--- a/packages/config/interface/index.ts
+++ b/packages/config/interface/index.ts
@@ -12,6 +12,7 @@ export type * from "./category";
 export type * from "./codeBlock";
 export type * from "./comment";
 export type * from "./docAnalysis";
+export type * from "./fadeTransition";
 export type * from "./footerGroup";
 export type * from "./footerInfo";
 export type * from "./friendLink";

--- a/packages/config/types.ts
+++ b/packages/config/types.ts
@@ -32,6 +32,7 @@ import type {
   Markdown,
   Private,
   RiskLink,
+  FadeTransition,
 } from "./interface";
 
 export type * from "./interface";
@@ -81,7 +82,6 @@ export interface TeekConfig {
    * @default true
    */
   viewTransition?: boolean;
-
   /**
    * 首页卡片栏列表位置
    *
@@ -146,6 +146,12 @@ export interface TeekConfig {
    * @default false
    */
   sidebarTrigger?: boolean;
+  /**
+   * 是否全局启用 fade 过渡动画
+   *
+   * @default true
+   */
+  fadeTransition?: boolean | FadeTransition;
   /**
    *  body 背景图片配置
    */

--- a/packages/theme-chalk/src/common/tk.scss
+++ b/packages/theme-chalk/src/common/tk.scss
@@ -27,3 +27,17 @@
     color: getCssVar("theme-color") !important;
   }
 }
+
+// 滚动动画效果
+.scroll__animate {
+  opacity: 0;
+  transform: translateY(20px);
+  transition:
+    opacity 0.6s ease-out,
+    transform 0.6s ease-out;
+
+  &.visible {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/packages/theme-chalk/src/components/theme/article-update.scss
+++ b/packages/theme-chalk/src/components/theme/article-update.scss
@@ -46,9 +46,10 @@
   }
 
   @include e(content) {
-    flex: 1;
     display: flex;
+    flex: 1;
     a {
+      width: 180px;
       padding-right: 10px;
       &:hover {
         text-decoration: underline;
@@ -57,6 +58,7 @@
     }
 
     @include m(date) {
+      max-width: 160px;
       margin-right: 15px;
       color: var(--vp-c-text-3);
       font-size: 14px;

--- a/packages/theme-chalk/src/components/theme/risk-link-page.scss
+++ b/packages/theme-chalk/src/components/theme/risk-link-page.scss
@@ -3,7 +3,7 @@
 
 @include b(risk-link) {
   top: 40%;
-  min-width: 450px;
+  min-width: 350px;
   max-width: 620px;
   background-color: getCssVar("bg-color-elm");
   padding: 20px;
@@ -11,7 +11,7 @@
   box-shadow: getCssVar("card-shadow");
 
   @media (max-width: 640px) {
-    min-width: calc(100% - 40px);
+    width: calc(100% - 60px);
   }
 
   @include e(header) {


### PR DESCRIPTION
- 在首页、归档页、卡片列表等页面添加淡入动画
- 新增 fadeTransition 配置项，用于控制全局或局部淡入动画
- 优化了动画效果和性能