### PR TITLE
fix: 🐞修复从文章面包屑导航第二级开始无法跳转到目录页问题

### DIFF
--- a/packages/components/theme/ArticleBreadcrumb/src/index.vue
+++ b/packages/components/theme/ArticleBreadcrumb/src/index.vue
@@ -39,9 +39,11 @@ const breadcrumbList = computed(() => {
       (index !== relativePathArrConst.length - 1 || breadcrumb.value.showCurrentName) &&
       fileName !== localeIndex.value
     ) {
+      // 处理多级面包屑 跳转到目录页, 加上前面的所有元素(以`/`分割)补全路径
+      const path = relativePathArrConst.slice(0, index + 1).join("/");
       classifyList.push({
         fileName,
-        url: theme.value.catalogues?.inv[item]?.url || "",
+        url: theme.value.catalogues?.inv[path]?.url || "",
       });
     }
   });


### PR DESCRIPTION

<img width="908" height="321" alt="image" src="https://github.com/user-attachments/assets/11108d95-010c-4148-a5a8-2ef20f693072" />
<img width="302" height="113" alt="image" src="https://github.com/user-attachments/assets/ad69d5b4-e6fa-44cf-847b-c6e61bcee6b6" />
