### PR TITLE
docs(link): 📚 更新案例文档中的链接和图片地址

### DIFF
--- a/docs/20.资源/05.案例.md
+++ b/docs/20.资源/05.案例.md
@@ -98,11 +98,11 @@ coverImg: https://vp.teek.top/blog/bg2.webp
   author: Teeker
   avatar: https://testingcf.jsdelivr.net/gh/Kele-Bingtang/static/user/avatar1.png
 - img: https://testingcf.jsdelivr.net/gh/Kele-Bingtang/static/vp-teek-cover/20250522213028.png
-  link: https://dotnetshare.com
+  link: https://docs.dot520.net
   name: Netshare
   desc: C#全栈知识体系
   author: Netshare
-  avatar: https://dotnetshare.com/csharplogo.svg
+  avatar: https://docs.dot520.net/csharplogo.svg
 - img: https://jenkinsguide.opsre.top/ghimgs/other/home.webp
   link: https://jenkinsguide.opsre.top/
   name: JenkinsGuide


### PR DESCRIPTION
- 将 Netshare 的链接从 https://dotnetshare.com 更新为 https://docs.dot520.net
- 将 Netshare 的头像地址从 https://dotnetshare.com/csharplogo.svg 更新为 https://docs.dot520.net/csharplogo.svg