### PR TITLE
fix(config): 🐞 修复文章页背景风格切换时不自动切换布局导致失效问题

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,6 +8,8 @@
 
 ### issue
 
+- [#204](https://github.com/Kele-Bingtang/vitepress-theme-teek/issues/204)：`frontmatter.date` 不存在时，获取文件的最后更新时间而不是当前逻辑的文件创建时间
+
 ### 已完成
 
 ## AR

--- a/docs/.vitepress/teek-config.template.ts
+++ b/docs/.vitepress/teek-config.template.ts
@@ -209,6 +209,7 @@ export const teekConfig = defineTeekConfig({
     autoPage: false, // 是否自动翻页
     pageSpeed: 4000, // 翻页间隔时间，单位：毫秒。autoPage 为 true 时生效
     dateFormat: "yyyy-MM-dd hh:mm:ss", // 精选文章的日期格式
+    dateUTC: true, // 是否使用 UTC 时间
   },
   // 分类卡片配置
   category: {
@@ -352,6 +353,7 @@ export const teekConfig = defineTeekConfig({
   articleAnalyze: {
     showIcon: true, // 作者、日期、分类、标签、字数、阅读时长、浏览量等文章信息的图标是否显示
     dateFormat: "yyyy-MM-dd hh:mm:ss", // 文章日期格式，首页和文章页解析日期时使用
+    dateUTC: true, // 是否使用 UTC 时间
     showInfo: true, // 是否展示作者、日期、分类、标签、字数、阅读时长、浏览量等文章信息，分别作用于首页和文章页
     showAuthor: true, // 是否展示作者
     showCreateDate: true, // 是否展示创建日期

--- a/docs/.vitepress/theme/components/teek-layout-provider.vue
+++ b/docs/.vitepress/theme/components/teek-layout-provider.vue
@@ -56,8 +56,10 @@ const handleThemeConfigChange = (config: TeekConfig, type: ChangeType) => {
   } else if (type === "bannerDescStyle") teekConfig.value.banner = { ...teekConfig.value.banner, ...config.banner };
   else if (type === "postStyle") teekConfig.value.post = { ...teekConfig.value.post, ...config.post };
   else if (type === "homeCardListPosition") teekConfig.value.homeCardListPosition = config.homeCardListPosition;
-  else if (type === "pageStyle") teekConfig.value.pageStyle = config.pageStyle;
-  else if (type === "postCoverImgMode") teekConfig.value.post = { ...teekConfig.value.post, ...config.post };
+  else if (type === "pageStyle") {
+    teekConfig.value.pageStyle = config.pageStyle;
+    teekConfig.value.themeEnhance = { ...teekConfig.value.themeEnhance, ...config.themeEnhance };
+  } else if (type === "postCoverImgMode") teekConfig.value.post = { ...teekConfig.value.post, ...config.post };
   else if (type === "themeSize") teekConfig.value.themeSize = config.themeSize;
   else if (type === "bannerImgWaves") teekConfig.value.banner = { ...teekConfig.value.banner, ...config.banner };
   else if (type === "loading") teekConfig.value.loading = config.loading;

--- a/docs/.vitepress/theme/components/theme-config.vue
+++ b/docs/.vitepress/theme/components/theme-config.vue
@@ -193,6 +193,7 @@ const pageStyle: ThemeEnhanceConfig = {
   ],
   change(value: TeekConfig["pageStyle"]) {
     teekConfig.value.pageStyle = value;
+    teekConfig.value.themeEnhance = { ...teekConfig.value.themeEnhance, layoutSwitch: { defaultMode: "original" } };
     change("pageStyle");
   },
 };


### PR DESCRIPTION
- 在 teek-config.template.ts 中添加 dateUTC 配置项用于控制是否使用 UTC 时间
- 更新 TODO.md 添加相关 issue 记录
- 修改 teek-layout-provider.vue 中的配置更新逻辑以同步更新 themeEnhance 配置
- 在 theme-config.vue 的页面样式切换中添加默认布局模式配置